### PR TITLE
[demo-vm-setup] added curl error handling

### DIFF
--- a/demo-vm-setup/setup-kudu-demo-vm.sh
+++ b/demo-vm-setup/setup-kudu-demo-vm.sh
@@ -9,7 +9,8 @@ dir_resolve()
 }
 
 : ${VIRTUALBOX_NAME:=cloudera-quickstart-vm-5.8.0-kudu-virtualbox}
-: ${VIRTUALBOX_URL:=http://cloudera-kudu-beta.s3.amazonaws.com/${VIRTUALBOX_NAME}.ova}
+OVF=${VIRTUALBOX_NAME}.ova
+: ${VIRTUALBOX_URL:=http://cloudera-kudu-beta.s3.amazonaws.com/${OVF}}
 
 # VM Settings default.
 : ${VM_NAME:=kudu-demo}
@@ -22,13 +23,15 @@ if ! which VBoxManage >/dev/null ; then
   exit 1
 fi
 
-# Download quickstart VM
-OVF=${VIRTUALBOX_NAME}.ova
-if [ -e ${VIRTUALBOX_NAME}.ova ]; then
+# Download quickstart VM appliance
+if [ -e ${OVF} ]; then
   echo Using previously downloaded image
 else
   echo "Downloading Virtualbox Image file: ${VIRTUALBOX_URL}"
-  curl -O ${VIRTUALBOX_URL}
+  if ! curl -fLSs ${VIRTUALBOX_URL} --output ${OVF}; then
+    echo "Failed to download VirtuaBox appliance from ${VIRTUALBOX_URL}"
+    exit 1
+  fi
 fi
 
 # Set up the VM for the first time if it doesn't already exist.


### PR DESCRIPTION
Stop once it's clear the VBox appliance has failed to download:
do not try to interpret S3 server output for HTTP 403 and other
errors as a valid VBox appliance file.

Also made curl to follow HTTP redirects, if any.
