### PR TITLE
Fix insert-loadgen example to handle insert errors

### DIFF
--- a/java/collectl/pom.xml
+++ b/java/collectl/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.kudu</groupId>
       <artifactId>kudu-client</artifactId>
-      <version>0.10.0</version>
+      <version>1.1.0</version>
     </dependency>
 
     <!-- for logging messages -->

--- a/java/insert-loadgen/pom.xml
+++ b/java/insert-loadgen/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.kudu</groupId>
       <artifactId>kudu-client</artifactId>
-      <version>0.10.0</version>
+      <version>1.1.0</version>
     </dependency>
 
     <!-- for logging messages -->

--- a/java/java-sample/pom.xml
+++ b/java/java-sample/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.kudu</groupId>
       <artifactId>kudu-client</artifactId>
-      <version>0.10.0</version>
+      <version>1.1.0</version>
     </dependency>
 
     <!-- for logging messages -->


### PR DESCRIPTION
This commit makes a few changes:

- multi-threading in insert-loadgen is removed. insert-loadgen used
  separate clients per-thread anyway, so there isn't much advantage to
  running with threads over just starting more instances as separate
  processes. The threading made shutting down on errors harder since the
  shutdown had to be communicated to all threads.
- insert-loadgen now fails on row errors by periodically checking the
  accumulated errors instead of ignoring them.
- All java projects have been updated to use the latest 1.1.0 Kudu
  client.