### PR TITLE
Allow setup-kudu-demo script to use a pre-built VM image

### DIFF
--- a/demo-vm-setup/setup-kudu-demo-vm.sh
+++ b/demo-vm-setup/setup-kudu-demo-vm.sh
@@ -8,10 +8,6 @@ dir_resolve()
   echo "`pwd -P`"
 }
 
-: ${VIRTUALBOX_NAME:=cloudera-quickstart-vm-5.10.0-kudu-virtualbox}
-OVF=${VIRTUALBOX_NAME}.ova
-: ${VIRTUALBOX_URL:=http://cloudera-kudu-beta.s3.amazonaws.com/${OVF}}
-
 # VM Settings default.
 : ${VM_NAME:=kudu-demo}
 : ${VM_NUM_CPUS:=2}
@@ -23,10 +19,30 @@ if ! which VBoxManage >/dev/null ; then
   exit 1
 fi
 
-# Download quickstart VM appliance
+OVF=cloudera-quickstart-vm-5.10.0-kudu-virtualbox.ova
+if [ $# -gt 2 ]; then
+    echo "$0 [--image|-i VM image file]"
+  exit 1
+elif [ $# -gt 0 ]; then
+  case $1 in
+    --image|-i)
+      OVF=$2
+      if [ ! -e $OVF ]; then
+        echo "Specified VM image file doesn't exist"
+        exit 1
+      fi
+      ;;
+    *)
+      echo "$0 [--image|-i VM image file]"
+      exit 1
+  esac
+fi
+
+# Use/download quickstart VM image
 if [ -e ${OVF} ]; then
-  echo Using previously downloaded image
+  echo Using image $OVF
 else
+  VIRTUALBOX_URL=http://cloudera-kudu-beta.s3.amazonaws.com/${OVF}
   echo "Downloading Virtualbox Image file: ${VIRTUALBOX_URL}"
   if ! curl -fLSs ${VIRTUALBOX_URL} --output ${OVF}; then
     echo "Failed to download VirtuaBox appliance from ${VIRTUALBOX_URL}"
@@ -35,7 +51,7 @@ else
 fi
 
 # Set up the VM for the first time if it doesn't already exist.
-if ! VBoxManage list vms | grep -q '"kudu-demo"'; then
+if ! VBoxManage list vms | grep -q '{$VM_NAME}'; then
   # Create a host only network interface
   VBoxManage hostonlyif create
 


### PR DESCRIPTION
setup-kudu-demo-vm.sh script currently either downloads
a VM image or let us use an already downloaded image.
It is easier for future testing if we allow it to use a pre-built
VM image in situations where we want to use an image built out
of quickstart-vm repository and then run few kudu-examples.

This change lets the script take an OVA file as an argument
and retains the original usage of either downloading the image
or using a downloaded image if it is present in current directory.

Testing: Verified that all 3 modes of input work as expected.